### PR TITLE
Enhance PubSub logging and switch lbxLog to DarkListBox

### DIFF
--- a/PubSubService.cs
+++ b/PubSubService.cs
@@ -86,7 +86,8 @@ namespace NetUtils {
 		}
 		private void DecodeChangeEvent(byte[] payload, RecordSchema schema, List<string> fieldsToFilter) {
 			var result = new CDCEventArgs();
-			LogEmit?.Invoke(this, $"Decoding event for schema: {schema.Name}");
+			LogEmit?.Invoke(this, $"<%debug%>Decoding event for schema: {schema.Name}");
+			LogEmit?.Invoke(this, $"<%Info%>Payload (base64): {Convert.ToBase64String(payload)}");
 			if (DebugBreak) Debugger.Break();
 			try {
 				using var stream = new MemoryStream(payload);

--- a/TesterFrm/DarkListBox.cs
+++ b/TesterFrm/DarkListBox.cs
@@ -25,35 +25,35 @@ public class DarkListBox : ListBox {
 		UpdateStyles();
 	}
 	private readonly Dictionary<string, Color> LogColors = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase) {
-		{"Error",Color.Red },
-		{"Warning",Color.Orange },
-		{"Info",Color.LightGreen },
-		{"Debug",Color.LightSkyBlue } };
+   { "CREATE", Color.LightGreen },
+	{ "UPDATE", Color.LightBlue },
+	{ "DELETE", Color.IndianRed },
+	{ "Error",  Color.Red },
+	{ "Warning", Color.Yellow },
+	{ "Info", Color.White },
+	{"Debug", Color.BlueViolet } };
 	protected override void OnDrawItem(DrawItemEventArgs e) {
 		if (e.Index < 0) return;
-
 		bool selected = (e.State & DrawItemState.Selected) == DrawItemState.Selected;
 		var bg = selected ? SelBgColor : BgColor;
 		var fg = selected ? SelFgColor : FgColor;
-
 		string text = GetItemText(Items[e.Index]);
-
-		// Extract tag and override color
-		var tag = Regex.Match(text, "<%(.*?)%>");
+		var tag = Regex.Match(text, "<%(.*?)%>");// Extract tag and override color
 		if (tag.Success) {
 			string key = tag.Groups[1].Value;
 			if (LogColors.TryGetValue(key, out var mappedColor))
-				fg = mappedColor;
 
+				fg = mappedColor;
 			text = Regex.Replace(text, @"<%.*?%>\s*", "");
 		}
 
 		var rect = new Rectangle(e.Bounds.X + 6, e.Bounds.Y + 2, e.Bounds.Width - 12, e.Bounds.Height - 4);
 
 		using (var bgBrush = new SolidBrush(bg))
-		using (var fgBrush = new SolidBrush(fg)) {
+		using (var fgBrush = new SolidBrush(fg))
+		using (Font boldf = new Font(e.Font??DefaultFont, newStyle: FontStyle.Bold)) {
 			e.Graphics.FillRectangle(bgBrush, e.Bounds);
-			e.Graphics.DrawString(text, e.Font, fgBrush, rect);
+			e.Graphics.DrawString(text, boldf, fgBrush, rect);
 		}
 
 		e.DrawFocusRectangle();

--- a/TesterFrm/MainForm.cs
+++ b/TesterFrm/MainForm.cs
@@ -202,7 +202,7 @@ namespace TesterFrm {
 		}
 
 		private void PubSubService_LogEmit(object? sender, string e) {
-			BeginInvoke(() => lbxLog.Items.Add($"<%Info%> LogEmitted = {e}"));
+			BeginInvoke(() => lbxLog.Items.Add(e));
 		}
 
 		private void _dtSoqlResults_RowChanged(object sender, DataRowChangeEventArgs e) {


### PR DESCRIPTION
- Added LogEmit event in PubSubService for centralized log messages
- Implemented PubSubService_LogEmit handler to display log messages in lbxLog
- Converted lbxLog to DarkListBox with dark background
- Removed old owner-draw and LogItem handling for lbxLog
- Added keyword-based color highlighting using <%%> tags
- Minor cleanup: removed redundant commented code, updated SalesforceService and SqlServer integration scripts